### PR TITLE
Add basic test for Flask app

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,14 @@
+import os
+import sys
+import pytest
+
+# Ensure the application module can be imported from the repository root
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import app
+
+
+def test_index_route():
+    client = app.app.test_client()
+    response = client.get('/')
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary
- add a simple pytest for the index route

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684141c32de08332ba02aa2029714408